### PR TITLE
fix: use native strictEqual for the internal asserts

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ stream.on('error', (err) => {
 })
 ```
 <a id="once"></a>
-### `once(stream, expected, is) => Promise<void>`
+### `once(stream, expectedOrCallback, is) => Promise<void>`
 Assert that a single log is expected.
 The function internally
 - assert log message `time` is less than or equal to the current time
@@ -143,9 +143,14 @@ function is (received, expected, msg) {
 
 await pinoTest.once(stream, expected, is) // doesn't throw an error
 await pinoTest.once(stream, { msg: 'bye world', level: 30 }, is) // throw an error
+
+// OR using a custom callback
+await pinoTest.once(stream, (received) => {
+  assert.strictEqual(received.msg, 'hello world')
+})
 ```
 <a id="consecutive"></a>
-### `consecutive(stream, expected, is) => Promise<void>`
+### `consecutive(stream, expectedOrCallbacks, is) => Promise<void>`
 Assert that consecutive logs are expected.
 The function internally
 - assert log message `time` is less than or equal to the current time
@@ -188,4 +193,12 @@ function is (received, expected, msg) {
 
 await pinoTest.consecutive(stream, expected, is) // doesn't throw an error
 await pinoTest.consecutive(stream, [{ msg: 'bye world', level: 30 }], is) // throw an error
+
+// OR using a custom callback
+await pinoTest.consecutive(stream, [
+  { msg: 'hello world', level: 30 },
+  (received) => {
+    assert.strictEqual(received.msg, 'hi world')
+  }
+])
 ```

--- a/pino-test.d.ts
+++ b/pino-test.d.ts
@@ -15,9 +15,9 @@ declare function sink({ destroyOnError, emitErrorEvent }?: { destroyOnError?: bo
 /**
  * Assert that a single log is expected.
  *
- * @param {import('node:stream').Transform} stream The stream to be tested.
+ * @param {Transform} stream The stream to be tested.
  * @param {object | Function} expectedOrCallback The expected value to be tested or a callback function to assert the log.
- * @param {Function} [assert=nodeAssert.deepStrictEqual] The assert function to be used when the expectedOrCallback parameter is an object.
+ * @param {Function} [assert=deepStrictEqual] The assert function to be used when the expectedOrCallback parameter is an object.
  *
  * @returns A promise that resolves when the expected value is equal to the stream value.
  * @throws If the expected value is not equal to the stream value.
@@ -43,9 +43,9 @@ declare function once(stream: Transform, expectedOrCallback: object | Function, 
 /**
  * Assert that consecutive logs are expected.
  *
- * @param {import('node:stream').Transform} stream The stream to be tested.
+ * @param {Transform} stream The stream to be tested.
  * @param {Array<object | Function>} expectedsOrCallbacks The array of expected values to be tested or callback functions.
- * @param {Function} [assert=nodeAssert.deepStrictEqual] The assert function to be used when the expectedOrCallback parameter is an object.
+ * @param {Function} [assert=deepStrictEqual] The assert function to be used when the expectedOrCallback parameter is an object.
  *
  * @returns A promise that resolves when the expected value is equal to the stream value.
  * @throws If the expected value is not equal to the stream value.

--- a/pino-test.d.ts
+++ b/pino-test.d.ts
@@ -15,43 +15,55 @@ declare function sink({ destroyOnError, emitErrorEvent }?: { destroyOnError?: bo
 /**
  * Assert that a single log is expected.
  *
- * @param {Transform} stream The stream to be tested.
- * @param {object} expected The expected value to be tested.
- * @param {function} [assert=deepStrictEqual] The assert function to be used.
+ * @param {import('node:stream').Transform} stream The stream to be tested.
+ * @param {object | Function} expectedOrCallback The expected value to be tested or a callback function to assert the log.
+ * @param {Function} [assert=nodeAssert.deepStrictEqual] The assert function to be used when the expectedOrCallback parameter is an object.
  *
  * @returns A promise that resolves when the expected value is equal to the stream value.
  * @throws If the expected value is not equal to the stream value.
+ * @throws If the the callback function throws an error.
  *
  * @example
- * const stream = pino.test.sink()
+ * const stream = pinoTest.sink()
  * const logger = pino(stream)
+ * 
  * logger.info('hello world')
+ * 
  * const expected = { msg: 'hello world', level: 30 }
- * await pino.test.once(stream, expected)
+ * await pinoTest.once(stream, expected)
+ * 
+ * logger.info('hello world 1')
+ * 
+ * await pinoTest.once(stream, (log) => {
+ *  assert.strictEqual(log.msg, 'hello world 1')
+ * })
  */
-declare function once(stream: Transform, expected: object, assert?: typeof deepStrictEqual): Promise<void>
+declare function once(stream: Transform, expectedOrCallback: object | Function, assert?: typeof deepStrictEqual): Promise<void>
 
 /**
  * Assert that consecutive logs are expected.
  *
- * @param {Transform} stream The stream to be tested.
- * @param {object} expected The expected value to be tested.
- * @param {function} [assert=deepStrictEqual] The assert function to be used.
+ * @param {import('node:stream').Transform} stream The stream to be tested.
+ * @param {Array<object | Function>} expectedsOrCallbacks The array of expected values to be tested or callback functions.
+ * @param {Function} [assert=nodeAssert.deepStrictEqual] The assert function to be used when the expectedOrCallback parameter is an object.
  *
  * @returns A promise that resolves when the expected value is equal to the stream value.
  * @throws If the expected value is not equal to the stream value.
+ * @throws If the callback function throws an error.
  *
  * @example
- * const stream = pino.test.sink()
+ * const stream = pinoTest.sink()
  * const logger = pino(stream)
+ * 
  * logger.info('hello world')
  * logger.info('hi world')
- * const expected = [
+ * 
+ * const expecteds = [
  *   { msg: 'hello world', level: 30 },
- *   { msg: 'hi world', level: 30 }
+ *   (log) => assert.strictEqual(log.msg, 'hi world')
  * ]
- * await pino.test.consecutive(stream, expected)
+ * await pinoTest.consecutive(stream, expecteds)
  */
-declare function consecutive(stream: Transform, expected: object[], assert?: typeof deepStrictEqual): Promise<void>
+declare function consecutive(stream: Transform, expectedsOrCallbacks: Array<object | Function>, assert?: typeof deepStrictEqual): Promise<void>
 
 export { consecutive, once, sink };

--- a/pino-test.js
+++ b/pino-test.js
@@ -38,9 +38,9 @@ function sink ({ destroyOnError = false, emitErrorEvent = false } = {}) {
 function check (chunk, expected, assert) {
   const { time, pid, hostname, ...chunkCopy } = chunk
 
-  assert(new Date(time) <= new Date(), true, 'time is greater than Date.now()')
-  assert(pid, process.pid)
-  assert(hostname, os.hostname())
+  nodeAssert.strictEqual(new Date(time) <= new Date(), true, 'time is greater than Date.now()')
+  nodeAssert.strictEqual(pid, process.pid)
+  nodeAssert.strictEqual(hostname, os.hostname())
   assert(chunkCopy, expected)
 }
 

--- a/test/pino-test.test.js
+++ b/test/pino-test.test.js
@@ -115,7 +115,7 @@ describe('once', () => {
     await pinoTest.once(stream, expected, is)
   })
 
-  test('once should own assert function called once', async () => {
+  test('once should calls own assert function once', async () => {
     const stream = pinoTest.sink()
     const instance = pino(stream)
     const customAssertFunction = mock.fn(is)
@@ -217,7 +217,7 @@ describe('consecutive', () => {
     await pinoTest.consecutive(stream, expected, is)
   })
 
-  test('consecutive should own assert function called twice', async () => {
+  test('consecutive should calls the own assert function twice', async () => {
     const stream = pinoTest.sink()
     const instance = pino(stream)
     const customAssertFunction = mock.fn(is)

--- a/test/pino-test.test.js
+++ b/test/pino-test.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { test } = require('node:test')
+const { mock, test } = require('node:test')
 const assert = require('node:assert')
 const { once } = require('node:events')
 const pino = require('pino')
@@ -112,6 +112,18 @@ test('once should pass with own assert function', async () => {
   await pinoTest.once(stream, expected, is)
 })
 
+test('once should own assert function called once', async () => {
+  const stream = pinoTest.sink()
+  const instance = pino(stream)
+  const customAssertFunction = mock.fn(is)
+
+  instance.info('hello world')
+
+  const expected = { msg: 'hello world', level: 30 }
+  await pinoTest.once(stream, expected, customAssertFunction)
+  assert.strictEqual(customAssertFunction.mock.calls.length, 1)
+})
+
 test('once should rejects with assert diff error', async ({ rejects }) => {
   const stream = pinoTest.sink()
   const instance = pino(stream)
@@ -198,6 +210,22 @@ test('consecutive should pass with own assert function', async () => {
     { msg: 'hi world', level: 30 }
   ]
   await pinoTest.consecutive(stream, expected, is)
+})
+
+test('consecutive should own assert function called twice', async () => {
+  const stream = pinoTest.sink()
+  const instance = pino(stream)
+  const customAssertFunction = mock.fn(is)
+
+  instance.info('hello world')
+  instance.info('hi world')
+
+  const expected = [
+    { msg: 'hello world', level: 30 },
+    { msg: 'hi world', level: 30 }
+  ]
+  await pinoTest.consecutive(stream, expected, customAssertFunction)
+  assert.strictEqual(customAssertFunction.mock.calls.length, 2)
 })
 
 test('consecutive should rejects with assert diff error', async () => {

--- a/test/pino-test.test.js
+++ b/test/pino-test.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { mock, test } = require('node:test')
+const { describe, mock, test } = require('node:test')
 const assert = require('node:assert')
 const { once } = require('node:events')
 const pino = require('pino')
@@ -12,268 +12,274 @@ function is (received, expected, msg) {
   }
 }
 
-test('sink should pass', async () => {
-  const stream = pinoTest.sink()
-  stream.write('{"hello":"world"}\n')
-  stream.write('{"hi":"world"}\n')
-  stream.end()
+describe('sink', () => {
+  test('sink should pass', async () => {
+    const stream = pinoTest.sink()
+    stream.write('{"hello":"world"}\n')
+    stream.write('{"hi":"world"}\n')
+    stream.end()
 
-  const expected = [
-    { hello: 'world' },
-    { hi: 'world' }
-  ]
+    const expected = [
+      { hello: 'world' },
+      { hi: 'world' }
+    ]
 
-  let i = 0
-  for await (const chunk of stream) {
-    assert.deepEqual(chunk, expected[i])
-    i++
-  }
-})
-
-test('sink should pass with invalid json', async () => {
-  const stream = pinoTest.sink()
-  stream.write('helloworld')
-  stream.end()
-})
-
-test('sink should destroy stream with invalid json', async () => {
-  const stream = pinoTest.sink({ destroyOnError: true })
-  stream.write('helloworld')
-  stream.end()
-
-  await once(stream, 'close')
-})
-
-test('sink should emit a stream error event with invalid json', async () => {
-  const stream = pinoTest.sink({ emitErrorEvent: true })
-  stream.write('helloworld')
-
-  stream.on('error', (err) => {
-    assert.match(err.message, /Unexpected token/)
+    let i = 0
+    for await (const chunk of stream) {
+      assert.deepEqual(chunk, expected[i])
+      i++
+    }
   })
 
-  stream.end()
-})
-
-test('sink should emit a stream error event and destroy the stream with invalid json', async () => {
-  const stream = pinoTest.sink({ destroyOnError: true, emitErrorEvent: true })
-  stream.write('helloworld')
-
-  stream.on('error', (err) => {
-    assert.match(err.message, /Unexpected token/)
+  test('sink should pass with invalid json', async () => {
+    const stream = pinoTest.sink()
+    stream.write('helloworld')
+    stream.end()
   })
 
-  stream.end()
+  test('sink should destroy stream with invalid json', async () => {
+    const stream = pinoTest.sink({ destroyOnError: true })
+    stream.write('helloworld')
+    stream.end()
 
-  await once(stream, 'close')
+    await once(stream, 'close')
+  })
+
+  test('sink should emit a stream error event with invalid json', async () => {
+    const stream = pinoTest.sink({ emitErrorEvent: true })
+    stream.write('helloworld')
+
+    stream.on('error', (err) => {
+      assert.match(err.message, /Unexpected token/)
+    })
+
+    stream.end()
+  })
+
+  test('sink should emit a stream error event and destroy the stream with invalid json', async () => {
+    const stream = pinoTest.sink({ destroyOnError: true, emitErrorEvent: true })
+    stream.write('helloworld')
+
+    stream.on('error', (err) => {
+      assert.match(err.message, /Unexpected token/)
+    })
+
+    stream.end()
+
+    await once(stream, 'close')
+  })
 })
 
-test('once should pass', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
+describe('once', () => {
+  test('once should pass', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
 
-  instance.info('hello world')
+    instance.info('hello world')
 
-  const expected = { msg: 'hello world', level: 30 }
-  await pinoTest.once(stream, expected)
+    const expected = { msg: 'hello world', level: 30 }
+    await pinoTest.once(stream, expected)
+  })
+
+  test('once should pass with object', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
+
+    instance.info({ hello: 'world' })
+
+    const expected = { hello: 'world', level: 30 }
+    await pinoTest.once(stream, expected)
+  })
+
+  test('once should rejects with object', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
+
+    instance.info({ hello: 'world', hi: 'world' })
+
+    const expected = { hello: 'world', level: 30 }
+
+    assert.rejects(
+      pinoTest.once(stream, expected),
+      /Expected values to be strictly deep-equal:/
+    )
+  })
+
+  test('once should pass with own assert function', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
+
+    instance.info('hello world')
+
+    const expected = { msg: 'hello world', level: 30 }
+    await pinoTest.once(stream, expected, is)
+  })
+
+  test('once should own assert function called once', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
+    const customAssertFunction = mock.fn(is)
+
+    instance.info('hello world')
+
+    const expected = { msg: 'hello world', level: 30 }
+    await pinoTest.once(stream, expected, customAssertFunction)
+    assert.strictEqual(customAssertFunction.mock.calls.length, 1)
+  })
+
+  test('once should rejects with assert diff error', async ({ rejects }) => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
+
+    instance.info('hello world')
+
+    const expected = { msg: 'by world', level: 30 }
+
+    assert.rejects(
+      pinoTest.once(stream, expected),
+      /Expected values to be strictly deep-equal:/
+    )
+  })
+
+  test('once should rejects with assert diff error and own assert function', async ({ rejects }) => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
+
+    instance.info('hello world')
+
+    const expected = { msg: 'by world', level: 30 }
+
+    assert.rejects(
+      pinoTest.once(stream, expected, is),
+      new Error('expected msg by world doesn\'t match the received one hello world')
+    )
+  })
 })
 
-test('once should pass with object', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
+describe('consecutive', () => {
+  test('consecutive should pass', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
 
-  instance.info({ hello: 'world' })
+    instance.info('hello world')
+    instance.info('hi world')
 
-  const expected = { hello: 'world', level: 30 }
-  await pinoTest.once(stream, expected)
-})
+    const expected = [
+      { msg: 'hello world', level: 30 },
+      { msg: 'hi world', level: 30 }
+    ]
+    await pinoTest.consecutive(stream, expected)
+  })
 
-test('once should rejects with object', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
+  test('consecutive should pass with object', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
 
-  instance.info({ hello: 'world', hi: 'world' })
+    instance.info({ hello: 'world' })
+    instance.info({ hi: 'world' })
 
-  const expected = { hello: 'world', level: 30 }
+    const expected = [
+      { hello: 'world', level: 30 },
+      { hi: 'world', level: 30 }
+    ]
+    await pinoTest.consecutive(stream, expected)
+  })
 
-  assert.rejects(
-    pinoTest.once(stream, expected),
-    /Expected values to be strictly deep-equal:/
-  )
-})
+  test('consecutive should rejects with object', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
 
-test('once should pass with own assert function', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
+    instance.info({ hello: 'world' })
+    instance.info({ hello: 'world', hi: 'world' })
 
-  instance.info('hello world')
+    const expected = [
+      { hello: 'world', level: 30 },
+      { hi: 'world', level: 30 }
+    ]
 
-  const expected = { msg: 'hello world', level: 30 }
-  await pinoTest.once(stream, expected, is)
-})
+    assert.rejects(
+      pinoTest.consecutive(stream, expected),
+      /Expected values to be strictly deep-equal:/
+    )
+  })
 
-test('once should own assert function called once', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
-  const customAssertFunction = mock.fn(is)
+  test('consecutive should pass with own assert function', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
 
-  instance.info('hello world')
+    instance.info('hello world')
+    instance.info('hi world')
 
-  const expected = { msg: 'hello world', level: 30 }
-  await pinoTest.once(stream, expected, customAssertFunction)
-  assert.strictEqual(customAssertFunction.mock.calls.length, 1)
-})
+    const expected = [
+      { msg: 'hello world', level: 30 },
+      { msg: 'hi world', level: 30 }
+    ]
+    await pinoTest.consecutive(stream, expected, is)
+  })
 
-test('once should rejects with assert diff error', async ({ rejects }) => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
+  test('consecutive should own assert function called twice', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
+    const customAssertFunction = mock.fn(is)
 
-  instance.info('hello world')
+    instance.info('hello world')
+    instance.info('hi world')
 
-  const expected = { msg: 'by world', level: 30 }
+    const expected = [
+      { msg: 'hello world', level: 30 },
+      { msg: 'hi world', level: 30 }
+    ]
+    await pinoTest.consecutive(stream, expected, customAssertFunction)
+    assert.strictEqual(customAssertFunction.mock.calls.length, 2)
+  })
 
-  assert.rejects(
-    pinoTest.once(stream, expected),
-    /Expected values to be strictly deep-equal:/
-  )
-})
+  test('consecutive should rejects with assert diff error', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
 
-test('once should rejects with assert diff error and own assert function', async ({ rejects }) => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
+    instance.info('hello world')
+    instance.info('hi world')
 
-  instance.info('hello world')
+    const expected = [
+      { msg: 'hello world', level: 30 },
+      { msg: 'by world', level: 30 }
+    ]
 
-  const expected = { msg: 'by world', level: 30 }
+    assert.rejects(
+      pinoTest.consecutive(stream, expected),
+      /Expected values to be strictly deep-equal:/
+    )
+  })
 
-  assert.rejects(
-    pinoTest.once(stream, expected, is),
-    new Error('expected msg by world doesn\'t match the received one hello world')
-  )
-})
+  test('consecutive should rejects with assert diff error and own assert function', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
 
-test('consecutive should pass', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
+    instance.info('hello world')
+    instance.info('hi world')
 
-  instance.info('hello world')
-  instance.info('hi world')
+    const expected = [
+      { msg: 'hello world', level: 30 },
+      { msg: 'by world', level: 30 }
+    ]
 
-  const expected = [
-    { msg: 'hello world', level: 30 },
-    { msg: 'hi world', level: 30 }
-  ]
-  await pinoTest.consecutive(stream, expected)
-})
+    await assert.rejects(
+      pinoTest.consecutive(stream, expected, is),
+      new Error('expected msg by world doesn\'t match the received one hi world')
+    )
+  })
 
-test('consecutive should pass with object', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
+  test('consecutive should reject if the stream ended before matching all logs', async () => {
+    const stream = pinoTest.sink()
+    const instance = pino(stream)
 
-  instance.info({ hello: 'world' })
-  instance.info({ hi: 'world' })
+    instance.info('hello world')
 
-  const expected = [
-    { hello: 'world', level: 30 },
-    { hi: 'world', level: 30 }
-  ]
-  await pinoTest.consecutive(stream, expected)
-})
-
-test('consecutive should rejects with object', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
-
-  instance.info({ hello: 'world' })
-  instance.info({ hello: 'world', hi: 'world' })
-
-  const expected = [
-    { hello: 'world', level: 30 },
-    { hi: 'world', level: 30 }
-  ]
-
-  assert.rejects(
-    pinoTest.consecutive(stream, expected),
-    /Expected values to be strictly deep-equal:/
-  )
-})
-
-test('consecutive should pass with own assert function', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
-
-  instance.info('hello world')
-  instance.info('hi world')
-
-  const expected = [
-    { msg: 'hello world', level: 30 },
-    { msg: 'hi world', level: 30 }
-  ]
-  await pinoTest.consecutive(stream, expected, is)
-})
-
-test('consecutive should own assert function called twice', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
-  const customAssertFunction = mock.fn(is)
-
-  instance.info('hello world')
-  instance.info('hi world')
-
-  const expected = [
-    { msg: 'hello world', level: 30 },
-    { msg: 'hi world', level: 30 }
-  ]
-  await pinoTest.consecutive(stream, expected, customAssertFunction)
-  assert.strictEqual(customAssertFunction.mock.calls.length, 2)
-})
-
-test('consecutive should rejects with assert diff error', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
-
-  instance.info('hello world')
-  instance.info('hi world')
-
-  const expected = [
-    { msg: 'hello world', level: 30 },
-    { msg: 'by world', level: 30 }
-  ]
-
-  assert.rejects(
-    pinoTest.consecutive(stream, expected),
-    /Expected values to be strictly deep-equal:/
-  )
-})
-
-test('consecutive should rejects with assert diff error and own assert function', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
-
-  instance.info('hello world')
-  instance.info('hi world')
-
-  const expected = [
-    { msg: 'hello world', level: 30 },
-    { msg: 'by world', level: 30 }
-  ]
-
-  await assert.rejects(
-    pinoTest.consecutive(stream, expected, is),
-    new Error('expected msg by world doesn\'t match the received one hi world')
-  )
-})
-
-test('consecutive should reject if the stream ended before matching all logs', async () => {
-  const stream = pinoTest.sink()
-  const instance = pino(stream)
-
-  instance.info('hello world')
-
-  const expected = [
-    { msg: 'hello world', level: 30 },
-    { msg: 'hi world', level: 30 }
-  ]
-  stream.end()
-  await assert.rejects(pinoTest.consecutive(stream, expected), new Error('Stream ended before all expected logs were received'))
+    const expected = [
+      { msg: 'hello world', level: 30 },
+      { msg: 'hi world', level: 30 }
+    ]
+    stream.end()
+    await assert.rejects(pinoTest.consecutive(stream, expected), new Error('Stream ended before all expected logs were received'))
+  })
 })

--- a/test/types/pino-test.test-d.ts
+++ b/test/types/pino-test.test-d.ts
@@ -19,4 +19,7 @@ expectError(pinoTest.consecutive(stream, { msg: '', level: 30 }))
 expectError(pinoTest.once(stream, ''))
 
 expectType<Promise<void>>(pinoTest.once(stream, { msg: '', level: 30 }))
+expectType<Promise<void>>(pinoTest.once(stream, (received: any) => received.msg === 'hello world'))
+
 expectType<Promise<void>>(pinoTest.consecutive(stream, [{ msg: '', level: 30 }]))
+expectType<Promise<void>>(pinoTest.consecutive(stream, [{ msg: '', level: 30 }, (received: any) => received.msg === 'hi world']))

--- a/test/types/pino-test.ts
+++ b/test/types/pino-test.ts
@@ -10,12 +10,13 @@ logger.info('by world')
 async function onceType() {
     const expected = { msg: 'hello world', level: 30 }
     await pinoTest.once(stream, expected)
+    await pinoTest.once(stream, (received: any) => received.msg === 'hello world')
 }
 
 async function consecutiveType() {
     const expected = [
         { msg: 'hello world', level: 30 },
-        { msg: 'hi world', level: 30 }
+        (received: any) => received.msg === 'hi world'
     ]
     await pinoTest.consecutive(stream, expected)
 }


### PR DESCRIPTION
1. the first commit fixes the internal assert
2. the second is a test refactor regrouping the tests by method name
3. the third renames the test titles

Closes #13 