### PR TITLE
feat: introduce waitFor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ npm install pino-test --save-dev
 ```
 
 ```js
-const test = require('node:test')
-const pino = require('pino')
-const pinoTest = require('pino-test')
+import { test } from 'node:test'
+import pino from 'pino'
+import pinoTest from 'pino-test'
 
 test('pino should log a info message', async () => {
   const stream = pinoTest.sink()
@@ -52,8 +52,8 @@ test('pino should log a info message using a own assert function', async () => {
 Create a Pino destination stream to easily inspect the logs processed by Pino.
 
 ```js
-const pino = require('pino')
-const pinoTest = require('pino-test')
+import pino from 'pino'
+import pinoTest from 'pino-test'
 
 const stream = pinoTest.sink()
 const logger = pino(stream)
@@ -67,8 +67,8 @@ stream.once('data', (data) => {
 ```
 Destroy the stream on error
 ```js
-const pino = require('pino')
-const pinoTest = require('pino-test')
+import pino from 'pino'
+import pinoTest from 'pino-test'
 
 const stream = pinoTest.sink({ destroyOnError: true })
 stream.write('helloworld')
@@ -80,8 +80,8 @@ stream.once('close', () => {
 ```
 Destroy and send error event on error
 ```js
-const pino = require('pino')
-const pinoTest = require('pino-test')
+import pino from 'pino'
+import pinoTest from 'pino-test'
 
 const stream = pinoTest.sink({ destroyOnError = false, emitErrorEvent = false })
 stream.write('helloworld')
@@ -97,8 +97,8 @@ stream.on('close', () => {
 ```
 Send error event on error
 ```js
-const pino = require('pino')
-const pinoTest = require('pino-test')
+import pino from 'pino'
+import pinoTest from 'pino-test'
 
 const stream = pinoTest.sink({ emitErrorEvent = false })
 stream.write('helloworld')
@@ -118,8 +118,8 @@ The function internally
 - uses the default `deepStrictEqual` assert function of the `node:assert` module.
 
 ```js
-const pino = require('pino')
-const pinoTest = require('pino-test')
+import pino from 'pino'
+import pinoTest from 'pino-test'
 
 const stream = pinoTest.sink()
 const logger = pino(stream)
@@ -160,8 +160,8 @@ The function internally
 - uses the default `deepStrictEqual` assert function of the `node:assert` module.
 
 ```js
-const pino = require('pino')
-const pinoTest = require('pino-test')
+import pino from 'pino'
+import pinoTest from 'pino-test'
 
 const stream = pinoTest.sink()
 const logger = pino(stream)
@@ -225,8 +225,8 @@ The function internally
 - `debug`: (default: false) Enable debug logging of received messages
 
 ```js
-const pino = require('pino')
-const pinoTest = require('pino-test')
+import pino from 'pino'
+import pinoTest from 'pino-test'
 
 const stream = pinoTest.sink()
 const logger = pino(stream)

--- a/pino-test.js
+++ b/pino-test.js
@@ -4,6 +4,8 @@ const nodeAssert = require('assert')
 const os = require('os')
 const split = require('split2')
 
+const DEFAULT_WAIT_FOR_TIMEOUT = 1000
+
 /**
  * Create a Pino destination stream to easily inspect the logs processed by Pino.
  *
@@ -127,6 +129,33 @@ async function consecutive (stream, expectedOrCallbacks, assert = nodeAssert.dee
   if (i < expectedOrCallbacks.length) {
     throw new Error('Stream ended before all expected logs were received')
   }
+}
+
+/**
+ * Assert a specific log is expected, ignoring the rest.
+ *
+ * @param {import('node:stream').Transform} stream The stream to be tested.
+ * @param {Array<object | Function>} expectedsOrCallbacks The array of expected values to be tested or callback functions.
+ * @param {Function} [assert=nodeAssert.deepStrictEqual] The assert function to be used when the expectedOrCallback parameter is an object.
+ * @param {Number} [timeout=1000] The time in milliseconds to wait for the expected value.
+ *
+ * @returns A promise that resolves when the expected value is equal to the stream value.
+ * @throws If the expected value is not equal to the stream value.
+ * @throws If the callback function throws an error.
+ * @throws If timeout is reached.
+ *
+ * @example
+ * const stream = pinoTest.sink()
+ * const logger = pino(stream)
+ *
+ * logger.debug('setting up server')
+ * logger.info('server started')
+ * logger.error('server crashed')
+ *
+ * await pinoTest.waitFor(stream, { msg: 'server started', level: 30 })
+ */
+async function waitFor (stream, expectedOrCallbacks, assert = nodeAssert.deepStrictEqual, timeout = DEFAULT_WAIT_FOR_TIMEOUT) {
+  // TODO implementation
 }
 
 module.exports = { sink, once, consecutive }

--- a/pino-test.js
+++ b/pino-test.js
@@ -4,8 +4,8 @@ const nodeAssert = require('assert')
 const os = require('os')
 const split = require('split2')
 
-const DEFAULT_WAIT_FOR_TIMEOUT = 1000
-
+const DEFAULT_WAIT_FOR_TIMEOUT = 1_000
+const DEFAULT_MAX_MESSAGES = 100
 /**
  * Create a Pino destination stream to easily inspect the logs processed by Pino.
  *
@@ -137,8 +137,10 @@ async function consecutive (stream, expectedOrCallbacks, assert = nodeAssert.dee
  * @param {import('node:stream').Transform} stream The stream to be tested.
  * @param {Array<object | Function>} expectedsOrCallbacks The array of expected values to be tested or callback functions.
  * @param {Function} [assert=nodeAssert.deepStrictEqual] The assert function to be used when the expectedOrCallback parameter is an object.
- * @param {Number} [timeout=1000] The time in milliseconds to wait for the expected value.
- *
+ * @param {Object} [options] Additional options when assert is a function.
+ * @param {Number} [options.timeout=1000] The time in milliseconds to wait for the expected value.
+ * @param {Number} [options.maxMessages=100] The maximum number of messages to wait for.
+ * @param {Boolean} [options.debug=false] If true, the stream will be logged to the console.
  * @returns A promise that resolves when the expected value is equal to the stream value.
  * @throws If the expected value is not equal to the stream value.
  * @throws If the callback function throws an error.
@@ -154,8 +156,53 @@ async function consecutive (stream, expectedOrCallbacks, assert = nodeAssert.dee
  *
  * await pinoTest.waitFor(stream, { msg: 'server started', level: 30 })
  */
-async function waitFor (stream, expectedOrCallbacks, assert = nodeAssert.deepStrictEqual, timeout = DEFAULT_WAIT_FOR_TIMEOUT) {
-  // TODO implementation
+async function waitFor (stream, expectedOrCallbacks, assert = nodeAssert.deepStrictEqual, options = {}) {
+  return new Promise((resolve, reject) => {
+    let assertFn = assert
+    let { maxMessages = DEFAULT_MAX_MESSAGES, timeout = DEFAULT_WAIT_FOR_TIMEOUT, debug = false } = options
+
+    // Handle case where assertOrOptions is actually options
+    if (typeof assert === 'object') {
+      assertFn = nodeAssert.deepStrictEqual
+      maxMessages = assert.maxMessages || DEFAULT_MAX_MESSAGES
+      timeout = assert.timeout || DEFAULT_WAIT_FOR_TIMEOUT
+      debug = assert.debug || false
+    }
+
+    let count = 0
+    const timeoutId = setTimeout(() => {
+      stream.off('data', fn)
+      stream.off('error', reject)
+      const identifier = typeof expectedOrCallbacks !== 'function' ? expectedOrCallbacks.msg : '[function]'
+      reject(new Error(`Timeout on waitFor: ${identifier}`))
+    }, timeout)
+
+    const fn = (message) => {
+      if (debug) {
+        console.log('waitFor received', message)
+      }
+
+      try {
+        check(message, expectedOrCallbacks, assertFn)
+        stream.off('data', fn)
+        stream.off('error', reject)
+        clearTimeout(timeoutId)
+        resolve()
+        return
+      } catch { }
+
+      count++
+      if (count > maxMessages) {
+        stream.off('data', fn)
+        stream.off('error', reject)
+        clearTimeout(timeoutId)
+        const identifier = typeof expectedOrCallbacks !== 'function' ? expectedOrCallbacks.msg : '[function]'
+        reject(new Error(`Max message count reached on waitFor: ${identifier}`))
+      }
+    }
+    stream.on('data', fn)
+    stream.on('error', reject)
+  })
 }
 
-module.exports = { sink, once, consecutive }
+module.exports = { sink, once, consecutive, waitFor }


### PR DESCRIPTION
I'm proposing to introduce a `waitFor` method, as it is a very useful way to wait for a specific log message as it was an event, see this test case as an example https://github.com/fastify/fastify-http-proxy/pull/405/files#diff-b59655a410d4b510490ef7061e70dfd99b3f0b95473c0300376ff7c918d47d73R299

```js
est('should call onDisconnect hook', async (t) => {
  const onDisconnect = () => {
    logger.info('onDisconnect called')
  }

  const wsReconnectOptions = {
    logs: true,
  }

  const { loggerSpy, logger, client } = await createServices({ t, wsReconnectOptions, wsHooks: { onDisconnect } })
  client.close()

  await waitForLogMessage(loggerSpy, 'onDisconnect called')
})
```

If you agree on it, I'm going for the implementation
